### PR TITLE
cleanup_spec < Fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bummr (1.1.1a)
+    bummr (1.2.0)
       rainbow
       thor
 

--- a/lib/bummr/cli.rb
+++ b/lib/bummr/cli.rb
@@ -43,7 +43,7 @@ module Bummr
         if outdated_gems.empty?
           puts "No outdated gems to update".color(:green)
         else
-          Bummr::Updater.new(outdated_gems).update_gems
+          Bummr::Updater.new(outdated_gems).update_outdated_gems
 
           git.rebase_interactive(BASE_BRANCH)
           test

--- a/lib/bummr/cli.rb
+++ b/lib/bummr/cli.rb
@@ -15,13 +15,14 @@ module Bummr
     end
     # :nocov: end
 
-    desc "update",
-      "Update outdated gems, run tests, bisect if tests fail\n\n" +
-      "--all: Update indirect dependencies\n" +
-      "--group: Specify a group from the Gemfile to update\n" +
-      "--gem: Specify a specific gem to update\n" +
-      "\n"
-
+    desc "update", "Update outdated gems, run tests, bisect if tests fail (options: --all, --group, --gem)"
+    long_desc <<-LONGDESC
+      Update outdated gems > Interactive rebase to pick-and-choose finalized gem updates > Run tests > Bisect if any test fails
+      \x5Options:
+      \x5 --all:   Update indirect dependencies
+      \x5 --group: Specify a group from the Gemfile to update
+      \x5 --gem:   Specify a specific gem to update
+    LONGDESC
 
     method_option :all, type: :boolean, default: false
     method_option :group, type: :string

--- a/lib/bummr/git.rb
+++ b/lib/bummr/git.rb
@@ -11,6 +11,11 @@ module Bummr
       system("git add #{files}")
     end
 
+    def files_staged?
+      # exit code 1 when there are files staged for commit
+      !system("git diff --staged --quiet")
+    end
+
     def commit(message)
       log "Commit: #{message}".color(:green)
       system("#{git_commit} -m '#{message}'")

--- a/lib/bummr/git.rb
+++ b/lib/bummr/git.rb
@@ -11,6 +11,8 @@ module Bummr
       system("git add #{files}")
     end
 
+    # NOTE: during active development this will catch any other files you may be working on
+    #       so don't leave random files staged without committing them
     def files_staged?
       # exit code 1 when there are files staged for commit
       !system("git diff --staged --quiet")

--- a/lib/bummr/updater.rb
+++ b/lib/bummr/updater.rb
@@ -34,6 +34,9 @@ module Bummr
       git.add("Gemfile.lock")
       git.add("vendor/cache")
 
+      return unless git.files_staged?
+      # ... something was changed
+
       # When the targeted gem itself is not modified, one of its dependencies must have been
       if gem[:installed] == updated_version
         message = "Update #{gem[:name]} dependencies"

--- a/lib/bummr/updater.rb
+++ b/lib/bummr/updater.rb
@@ -21,12 +21,6 @@ module Bummr
 
       updated_version = updated_version_for(gem)
 
-      message = if updated_version
-        "Update #{gem[:name]} from #{gem[:installed]} to #{updated_version}"
-      else
-        "Update dependencies for #{gem[:name]}"
-      end
-
       if gem[:installed] == updated_version
         log("#{gem[:name]} not updated")
         return
@@ -39,6 +33,13 @@ module Bummr
       git.add("Gemfile")
       git.add("Gemfile.lock")
       git.add("vendor/cache")
+
+      # When the targeted gem itself is not modified, one of its dependencies must have been
+      if gem[:installed] == updated_version
+        message = "Update #{gem[:name]} dependencies"
+      else
+        message = "Update #{gem[:name]} from #{gem[:installed]} to #{updated_version}"
+      end
       git.commit(message)
     end
 

--- a/lib/bummr/updater.rb
+++ b/lib/bummr/updater.rb
@@ -21,12 +21,13 @@ module Bummr
 
       updated_version = updated_version_for(gem)
 
+      # If the gem could not be updated at all
       if gem[:installed] == updated_version
         log("#{gem[:name]} not updated")
-        return
-      end
+        # might still be dependency updates, so cannot stop here
 
-      if gem[:newest] != updated_version
+      # If the gem was updated, but not to latest
+      elsif gem[:newest] != updated_version
         log("#{gem[:name]} not updated from #{gem[:installed]} to latest: #{gem[:newest]}")
       end
 

--- a/lib/bummr/updater.rb
+++ b/lib/bummr/updater.rb
@@ -19,15 +19,16 @@ module Bummr
       puts "Updating #{gem[:name]}: #{index + 1} of #{@outdated_gems.count}"
       system("bundle update #{gem[:name]}")
 
-      updated_version = updated_version_for(gem)
+      # Get the current (maybe new?) bundled version for this gem
+      bundled_version = bundled_version_for(gem)
 
       # If the gem could not be updated at all
-      if gem[:installed] == updated_version
+      if gem[:installed] == bundled_version
         log("#{gem[:name]} not updated")
         # might still be dependency updates, so cannot stop here
 
       # If the gem was updated, but not to latest
-      elsif gem[:newest] != updated_version
+      elsif gem[:newest] != bundled_version
         log("#{gem[:name]} not updated from #{gem[:installed]} to latest: #{gem[:newest]}")
       end
 
@@ -39,15 +40,16 @@ module Bummr
       # ... something was changed
 
       # When the targeted gem itself is not modified, one of its dependencies must have been
-      if gem[:installed] == updated_version
+      if gem[:installed] == bundled_version
         message = "Update #{gem[:name]} dependencies"
       else
-        message = "Update #{gem[:name]} from #{gem[:installed]} to #{updated_version}"
+        message = "Update #{gem[:name]} from #{gem[:installed]} to #{bundled_version}"
       end
       git.commit(message)
     end
 
-    def updated_version_for(gem)
+    # NOTE: cannot be private method because it is tested specifically by updater_spec.rb
+    def bundled_version_for(gem)
       string = %x{bundle list --paths | grep "#{gem[:name]}"}
       if string.empty?
         # :nocov: We don't need to test when an exception happens

--- a/lib/bummr/updater.rb
+++ b/lib/bummr/updater.rb
@@ -7,7 +7,7 @@ module Bummr
       @outdated_gems = outdated_gems
     end
 
-    def update_gems
+    def update_outdated_gems
       puts "Updating outdated gems".color(:green)
 
       @outdated_gems.each_with_index do |gem, index|

--- a/lib/bummr/updater.rb
+++ b/lib/bummr/updater.rb
@@ -44,6 +44,12 @@ module Bummr
 
     def updated_version_for(gem)
       string = %x{bundle list --paths | grep "#{gem[:name]}"}
+      if string.empty?
+        # :nocov: We don't need to test when an exception happens
+        # Raise a understandable error message
+        raise "FATAL: Unable to find '#{gem[:name]}' within 'bundle list --paths'."
+        # :nocov: end
+      end
       string.match(/#{File::SEPARATOR}#{gem[:name]}-(.*)$/)[1]
     end
   end

--- a/lib/bummr/version.rb
+++ b/lib/bummr/version.rb
@@ -1,3 +1,3 @@
 module Bummr
-  VERSION = "1.1.1a"
+  VERSION = "1.2.0"
 end

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -33,7 +33,7 @@ describe Bummr::CLI do
     context "when user agrees to move forward" do
       def mock_bummr_standard_flow
         updater = double
-        allow(updater).to receive(:update_gems)
+        allow(updater).to receive(:update_outdated_gems)
 
         expect(cli).to receive(:display_info)
         expect(cli).to receive(:yes?).and_return(true)

--- a/spec/lib/updater_spec.rb
+++ b/spec/lib/updater_spec.rb
@@ -102,6 +102,7 @@ describe Bummr::Updater do
 
         allow(updater).to receive(:system)
         allow(git).to receive(:add)
+        allow(git).to receive(:files_staged?).and_return true
         mock_log_commit_puts
 
         updater.update_gem(gem, 0)
@@ -124,6 +125,7 @@ describe Bummr::Updater do
 
         allow(updater).to receive(:system)
         allow(git).to receive(:add)
+        allow(git).to receive(:files_staged?).and_return true
         mock_log_commit_puts
 
         updater.update_gem(gem, 0)

--- a/spec/lib/updater_spec.rb
+++ b/spec/lib/updater_spec.rb
@@ -7,16 +7,19 @@ describe Bummr::Updater do
 
   let(:outdated_gems) {
     [
-      { name: "myGem", installed: "0.3.2", newest: "0.3.5" },
+      { name: "myGem",    installed: "0.3.2",    newest: "0.3.5" },
       { name: "otherGem", installed: "1.3.2.23", newest: "1.6.5" },
-      { name: "thirdGem", installed: "4.3.4", newest: "5.6.45" },
+      { name: "thirdGem", installed: "4.3.4",    newest: "5.6.45" },
     ]
   }
   let(:gem) { outdated_gems[0] }
+
   let(:updater) { described_class.new(outdated_gems) }
-  let(:newest) { outdated_gems[0][:newest] }
-  let(:installed) { outdated_gems[0][:installed] }
+
+  let(:newest_version)       { outdated_gems[0][:newest] }
+  let(:installed_version)    { outdated_gems[0][:installed] }
   let(:intermediate_version) { "0.3.4" }
+
   let(:update_cmd) { "bundle update #{gem[:name]}" }
   let(:git) { Bummr::Git.instance }
 
@@ -50,16 +53,18 @@ describe Bummr::Updater do
 
     it "attempts to update the gem" do
       allow(updater).to receive(:system).with(update_cmd)
-      allow(updater).to receive(:bundled_version_for).with(gem).and_return installed
+      allow(updater).to receive(:bundled_version_for).with(gem).and_return installed_version
       mock_log_commit_puts
 
       updater.update_gem(gem, 0)
+
+      # NOTE: No assertions, so this is just a smoke-test (ensure the code runs without an exception)
     end
 
     context "not updated at all" do
       it "logs that it's not updated to the latest" do
         allow(updater).to receive(:system).with(update_cmd)
-        allow(updater).to receive(:bundled_version_for).with(gem).and_return installed
+        allow(updater).to receive(:bundled_version_for).with(gem).and_return installed_version
         mock_log_commit_puts
 
         updater.update_gem(gem, 0)
@@ -69,7 +74,7 @@ describe Bummr::Updater do
 
       it "doesn't commit anything" do
         allow(updater).to receive(:system).with(update_cmd)
-        allow(updater).to receive(:bundled_version_for).with(gem).and_return installed
+        allow(updater).to receive(:bundled_version_for).with(gem).and_return installed_version
         mock_log_commit_puts
 
         updater.update_gem(gem, 0)
@@ -116,7 +121,7 @@ describe Bummr::Updater do
 
     context "updated the gem to the latest" do
       before(:each) do
-        allow(updater).to receive(:bundled_version_for).and_return newest
+        allow(updater).to receive(:bundled_version_for).and_return newest_version
       end
 
       it "commits" do

--- a/spec/lib/updater_spec.rb
+++ b/spec/lib/updater_spec.rb
@@ -74,10 +74,28 @@ describe Bummr::Updater do
         expect(updater).to have_received(:log).with("#{gem[:name]} not updated")
       end
 
-      it "doesn't commit anything" do
-        updater.update_gem(gem, 0)
+      context "and no dependencies were updated" do
+        it "doesn't commit anything" do
+          updater.update_gem(gem, 0)
 
-        expect(git).to_not have_received(:commit)
+          expect(git).to_not have_received(:commit)
+        end
+      end
+      context "and dependencies were updated" do
+        it "commits" do
+          commit_message =
+            "Update #{gem[:name]} dependencies"
+
+          allow(git).to receive(:add)
+          allow(git).to receive(:files_staged?).and_return true
+
+          updater.update_gem(gem, 0)
+
+          expect(git).to have_received(:add).with("Gemfile")
+          expect(git).to have_received(:add).with("Gemfile.lock")
+          expect(git).to have_received(:add).with("vendor/cache")
+          expect(git).to have_received(:commit).with(commit_message)
+        end
       end
     end
 

--- a/spec/lib/updater_spec.rb
+++ b/spec/lib/updater_spec.rb
@@ -20,7 +20,6 @@ describe Bummr::Updater do
   let(:installed_version)    { outdated_gems[0][:installed] }
   let(:intermediate_version) { "0.3.4" }
 
-  let(:update_cmd) { "bundle update #{gem[:name]}" }
   let(:git) { Bummr::Git.instance }
 
   describe "#update_outdated_gems" do
@@ -45,16 +44,16 @@ describe Bummr::Updater do
       %x{rm -rf vendor/cache}
     end
 
-    def mock_log_commit_puts
+    def mock_system_log_commit_puts
+      allow(updater).to receive(:system)
       allow(updater).to receive(:log)
       allow(updater).to receive(:puts) # NOOP this function call
       allow(git).to receive(:commit)
     end
 
     it "attempts to update the gem" do
-      allow(updater).to receive(:system).with(update_cmd)
       allow(updater).to receive(:bundled_version_for).with(gem).and_return installed_version
-      mock_log_commit_puts
+      mock_system_log_commit_puts
 
       updater.update_gem(gem, 0)
 
@@ -63,9 +62,8 @@ describe Bummr::Updater do
 
     context "not updated at all" do
       it "logs that it's not updated to the latest" do
-        allow(updater).to receive(:system).with(update_cmd)
         allow(updater).to receive(:bundled_version_for).with(gem).and_return installed_version
-        mock_log_commit_puts
+        mock_system_log_commit_puts
 
         updater.update_gem(gem, 0)
 
@@ -73,9 +71,8 @@ describe Bummr::Updater do
       end
 
       it "doesn't commit anything" do
-        allow(updater).to receive(:system).with(update_cmd)
         allow(updater).to receive(:bundled_version_for).with(gem).and_return installed_version
-        mock_log_commit_puts
+        mock_system_log_commit_puts
 
         updater.update_gem(gem, 0)
 
@@ -93,8 +90,7 @@ describe Bummr::Updater do
       it "logs that it's not updated to the latest" do
         not_latest_message =
           "#{gem[:name]} not updated from #{gem[:installed]} to latest: #{gem[:newest]}"
-        allow(updater).to receive(:system)
-        mock_log_commit_puts
+        mock_system_log_commit_puts
 
         updater.update_gem(gem, 0)
 
@@ -105,10 +101,9 @@ describe Bummr::Updater do
         commit_message =
           "Update #{gem[:name]} from #{gem[:installed]} to #{intermediate_version}"
 
-        allow(updater).to receive(:system)
         allow(git).to receive(:add)
         allow(git).to receive(:files_staged?).and_return true
-        mock_log_commit_puts
+        mock_system_log_commit_puts
 
         updater.update_gem(gem, 0)
 
@@ -128,10 +123,9 @@ describe Bummr::Updater do
         commit_message =
           "Update #{gem[:name]} from #{gem[:installed]} to #{gem[:newest]}"
 
-        allow(updater).to receive(:system)
         allow(git).to receive(:add)
         allow(git).to receive(:files_staged?).and_return true
-        mock_log_commit_puts
+        mock_system_log_commit_puts
 
         updater.update_gem(gem, 0)
 

--- a/spec/lib/updater_spec.rb
+++ b/spec/lib/updater_spec.rb
@@ -35,6 +35,8 @@ describe Bummr::Updater do
     end
   end
 
+  # ----------------
+
   describe "#update_gem" do
     # Ensure this directory exists to be added
     before do
@@ -60,37 +62,34 @@ describe Bummr::Updater do
       # NOTE: No assertions, so this is just a smoke-test (ensure the code runs without an exception)
     end
 
-    context "not updated at all" do
-      it "logs that it's not updated to the latest" do
+    context "gem not updated" do
+      before(:each) do
         allow(updater).to receive(:bundled_version_for).with(gem).and_return installed_version
         mock_system_log_commit_puts
+      end
 
+      it "logs that it was not updated" do
         updater.update_gem(gem, 0)
 
         expect(updater).to have_received(:log).with("#{gem[:name]} not updated")
       end
 
       it "doesn't commit anything" do
-        allow(updater).to receive(:bundled_version_for).with(gem).and_return installed_version
-        mock_system_log_commit_puts
-
         updater.update_gem(gem, 0)
 
         expect(git).to_not have_received(:commit)
       end
     end
 
-    context "not updated to the newest version" do
+    context "gem not updated to the newest version" do
       before(:each) do
-        allow(updater).to receive(:bundled_version_for).with(gem).and_return(
-          intermediate_version
-        )
+        allow(updater).to receive(:bundled_version_for).with(gem).and_return intermediate_version
+        mock_system_log_commit_puts
       end
 
       it "logs that it's not updated to the latest" do
         not_latest_message =
           "#{gem[:name]} not updated from #{gem[:installed]} to latest: #{gem[:newest]}"
-        mock_system_log_commit_puts
 
         updater.update_gem(gem, 0)
 
@@ -103,7 +102,6 @@ describe Bummr::Updater do
 
         allow(git).to receive(:add)
         allow(git).to receive(:files_staged?).and_return true
-        mock_system_log_commit_puts
 
         updater.update_gem(gem, 0)
 
@@ -114,9 +112,10 @@ describe Bummr::Updater do
       end
     end
 
-    context "updated the gem to the latest" do
+    context "gem updated to the latest" do
       before(:each) do
-        allow(updater).to receive(:bundled_version_for).and_return newest_version
+        allow(updater).to receive(:bundled_version_for).with(gem).and_return newest_version
+        mock_system_log_commit_puts
       end
 
       it "commits" do
@@ -125,7 +124,6 @@ describe Bummr::Updater do
 
         allow(git).to receive(:add)
         allow(git).to receive(:files_staged?).and_return true
-        mock_system_log_commit_puts
 
         updater.update_gem(gem, 0)
 
@@ -136,6 +134,8 @@ describe Bummr::Updater do
       end
     end
   end # end #update_gem
+
+  # ----------------
 
   describe "#bundled_version_for" do
     it "returns the correct version from bundle list" do

--- a/spec/lib/updater_spec.rb
+++ b/spec/lib/updater_spec.rb
@@ -20,12 +20,12 @@ describe Bummr::Updater do
   let(:update_cmd) { "bundle update #{gem[:name]}" }
   let(:git) { Bummr::Git.instance }
 
-  describe "#update_gems" do
+  describe "#update_outdated_gems" do
     it "calls update_gem on each gem" do
       allow(updater).to receive(:update_gem)
       allow(updater).to receive(:puts) # NOOP this function call
 
-      updater.update_gems
+      updater.update_outdated_gems
 
       outdated_gems.each_with_index do |gem, index|
         expect(updater).to have_received(:update_gem).with(gem, index)

--- a/spec/lib/updater_spec.rb
+++ b/spec/lib/updater_spec.rb
@@ -50,7 +50,7 @@ describe Bummr::Updater do
 
     it "attempts to update the gem" do
       allow(updater).to receive(:system).with(update_cmd)
-      allow(updater).to receive(:updated_version_for).with(gem).and_return installed
+      allow(updater).to receive(:bundled_version_for).with(gem).and_return installed
       mock_log_commit_puts
 
       updater.update_gem(gem, 0)
@@ -59,7 +59,7 @@ describe Bummr::Updater do
     context "not updated at all" do
       it "logs that it's not updated to the latest" do
         allow(updater).to receive(:system).with(update_cmd)
-        allow(updater).to receive(:updated_version_for).with(gem).and_return installed
+        allow(updater).to receive(:bundled_version_for).with(gem).and_return installed
         mock_log_commit_puts
 
         updater.update_gem(gem, 0)
@@ -69,7 +69,7 @@ describe Bummr::Updater do
 
       it "doesn't commit anything" do
         allow(updater).to receive(:system).with(update_cmd)
-        allow(updater).to receive(:updated_version_for).with(gem).and_return installed
+        allow(updater).to receive(:bundled_version_for).with(gem).and_return installed
         mock_log_commit_puts
 
         updater.update_gem(gem, 0)
@@ -80,7 +80,7 @@ describe Bummr::Updater do
 
     context "not updated to the newest version" do
       before(:each) do
-        allow(updater).to receive(:updated_version_for).with(gem).and_return(
+        allow(updater).to receive(:bundled_version_for).with(gem).and_return(
           intermediate_version
         )
       end
@@ -116,7 +116,7 @@ describe Bummr::Updater do
 
     context "updated the gem to the latest" do
       before(:each) do
-        allow(updater).to receive(:updated_version_for).and_return newest
+        allow(updater).to receive(:bundled_version_for).and_return newest
       end
 
       it "commits" do
@@ -138,13 +138,13 @@ describe Bummr::Updater do
     end
   end # end #update_gem
 
-  describe "#updated_version_for" do
+  describe "#bundled_version_for" do
     it "returns the correct version from bundle list" do
       allow(updater).to receive(:`).with(
         "bundle list --paths | grep \"#{gem[:name]}\""
       ).and_return("asdf/asdf/asdf/#{gem[:name]}-3.5.2")
 
-      expect(updater.updated_version_for(gem)).to eq "3.5.2"
+      expect(updater.bundled_version_for(gem)).to eq "3.5.2"
     end
 
     it "returns the correct version when there are similarly named gems" do


### PR DESCRIPTION
- Modified update command's thor CLI description
- renamed `update_gems` => `update_outdated_gems`. It was too similar to `update_gem` method
- Raise human friendly exception within `updated_version_for`
- Fixed commit message to actually differ when only dependencies are updated
- Skip commit if no changes are staged
- Fixed issue that would incorrectly postpone merging dependency only changes into a later commit
- renamed `updated_version_for` => `bundled_version_for`. Better matches its functionality
- Updated some variables within updater_spec.rb
- Make each context in updater_spec consistent with a before(:each) block
- Add an example for when only dependencies are updated. Coverage is now 100%