### PR TITLE
fixes < Enhanced output

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bummr (1.2.0)
+    bummr (1.2.1a)
       rainbow
       thor
 

--- a/lib/bummr/git.rb
+++ b/lib/bummr/git.rb
@@ -19,7 +19,7 @@ module Bummr
     end
 
     def commit(message)
-      log "Commit: #{message}".color(:green)
+      log("Commit:".color(:green) + %Q| "#{message}"|)
       system("#{git_commit} -m '#{message}'")
     end
 

--- a/lib/bummr/log.rb
+++ b/lib/bummr/log.rb
@@ -2,7 +2,7 @@ module Bummr
   module Log
     def log(message)
       puts message
-      system("touch log/bummr.log && echo '#{message}' >> log/bummr.log")
+      system("touch log/bummr.log && echo '#{Rainbow.uncolor(message)}' >> log/bummr.log")
     end
   end
 end

--- a/lib/bummr/outdated.rb
+++ b/lib/bummr/outdated.rb
@@ -9,13 +9,15 @@ module Bummr
     def outdated_gems(options = {})
       results = []
 
-      bundle_options =  ""
-      bundle_options << " --parseable" if Gem::Version.new(Bundler::VERSION) >= Gem::Version.new("2")
-      bundle_options << " --strict" unless options[:all_gems]
-      bundle_options << " --group #{options[:group]}" if options[:group]
-      bundle_options << " #{options[:gem]}" if options[:gem]
+      bundle_options = []
+      bundle_options << "--parseable" if Gem::Version.new(Bundler::VERSION) >= Gem::Version.new("2")
+      bundle_options << "--strict" unless options[:all_gems]
+      bundle_options << "--group #{options[:group]}" if options[:group]
+      bundle_options << "#{options[:gem]}" if options[:gem]
 
-      Open3.popen2("bundle outdated" + bundle_options) do |_std_in, std_out|
+      cmd = "bundle outdated #{bundle_options.join(' ')}"
+      puts "Find Outdated Gems: '#{cmd}'"
+      Open3.popen2(cmd) do |_std_in, std_out|
         while line = std_out.gets
           puts line # TODO: remove this if possible (pointless for spec tests)
           gem = parse_gem_from(line)

--- a/lib/bummr/updater.rb
+++ b/lib/bummr/updater.rb
@@ -16,7 +16,8 @@ module Bummr
     end
 
     def update_gem(gem, index)
-      puts "Updating #{gem[:name]}: #{index + 1} of #{@outdated_gems.count}"
+      puts "------------\nUpdating #{gem[:name]}: #{index + 1} of #{@outdated_gems.count}"
+
       system("bundle update #{gem[:name]}")
 
       # Get the current (maybe new?) bundled version for this gem

--- a/lib/bummr/updater.rb
+++ b/lib/bummr/updater.rb
@@ -16,7 +16,7 @@ module Bummr
     end
 
     def update_gem(gem, index)
-      puts "------------\nUpdating #{gem[:name]}: #{index + 1} of #{@outdated_gems.count}"
+      puts "------------\nUpdating #{gem[:name].color(:magenta)}: #{index + 1} of #{@outdated_gems.count}"
 
       system("bundle update #{gem[:name]}")
 
@@ -25,12 +25,12 @@ module Bummr
 
       # If the gem could not be updated at all
       if gem[:installed] == bundled_version
-        log("#{gem[:name]} not updated")
+        log("Updating #{gem[:name]} cannot be completed".color(:yellow))
         # might still be dependency updates, so cannot stop here
 
       # If the gem was updated, but not to latest
       elsif gem[:newest] != bundled_version
-        log("#{gem[:name]} not updated from #{gem[:installed]} to latest: #{gem[:newest]}")
+        log("Newer #{gem[:name]} installed".color(:yellow) + " - updated from #{gem[:installed]} to #{bundled_version}" + " (latest: #{gem[:newest]})".color(:green))
       end
 
       git.add("Gemfile")

--- a/lib/bummr/updater.rb
+++ b/lib/bummr/updater.rb
@@ -31,6 +31,10 @@ module Bummr
       # If the gem was updated, but not to latest
       elsif gem[:newest] != bundled_version
         log("Newer #{gem[:name]} installed".color(:yellow) + " - updated from #{gem[:installed]} to #{bundled_version}" + " (latest: #{gem[:newest]})".color(:green))
+
+      # Is using the latest version
+      else
+        log("Latest #{gem[:name]} installed - updated from #{gem[:installed]} to #{bundled_version.color(:green)}")
       end
 
       git.add("Gemfile")

--- a/lib/bummr/version.rb
+++ b/lib/bummr/version.rb
@@ -1,3 +1,3 @@
 module Bummr
-  VERSION = "1.2.0"
+  VERSION = "1.2.1a".freeze
 end

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -55,7 +55,7 @@ describe Bummr::CLI do
           expect(cli).to receive(:check)
           expect(cli).to receive(:log)
           expect(cli).to receive(:system).with("bundle install")
-          expect(cli).to receive(:puts).with("No outdated gems to update".color(:green))
+          expect(cli).to receive(:puts).with("No outdated gems to update")
 
           cli.update
         end
@@ -126,7 +126,7 @@ describe Bummr::CLI do
           expect(cli).to receive(:check)
           expect(cli).to receive(:log)
           expect(cli).to receive(:system).with("bundle install")
-          expect(cli).to receive(:puts).with("No outdated gems to update".color(:green))
+          expect(cli).to receive(:puts).with("No outdated gems to update")
 
           cli.update
         end

--- a/spec/lib/git_spec.rb
+++ b/spec/lib/git_spec.rb
@@ -26,7 +26,7 @@ describe Bummr::Git do
       git.commit(commit_message)
 
       expect(git).to have_received(:log).with(
-        /Commit: #{commit_message}/
+        %Q|Commit: "#{commit_message}"|
       )
     end
 

--- a/spec/lib/remover_spec.rb
+++ b/spec/lib/remover_spec.rb
@@ -22,7 +22,7 @@ describe Bummr::Remover do
       remover.remove_commit(sha)
 
       expect(remover).to have_received(:log).with(
-        "Bad commit: commit message, #{sha}".color(:red)
+        "Bad commit: commit message, #{sha}"
       )
     end
 

--- a/spec/lib/updater_spec.rb
+++ b/spec/lib/updater_spec.rb
@@ -139,6 +139,15 @@ describe Bummr::Updater do
         mock_system_log_commit_puts
       end
 
+      it "logs that was updated to the latest" do
+        latest_message =
+          "Latest #{gem[:name]} installed - updated from #{gem[:installed]} to #{gem[:newest]}"
+
+        updater.update_gem(gem, 0)
+
+        expect(updater).to have_received(:log).with(latest_message)
+      end
+
       it "commits" do
         commit_message =
           "Update #{gem[:name]} from #{gem[:installed]} to #{gem[:newest]}"

--- a/spec/lib/updater_spec.rb
+++ b/spec/lib/updater_spec.rb
@@ -69,9 +69,12 @@ describe Bummr::Updater do
       end
 
       it "logs that it was not updated" do
+        cannot_update_message =
+          "Updating #{gem[:name]} cannot be completed"
+
         updater.update_gem(gem, 0)
 
-        expect(updater).to have_received(:log).with("#{gem[:name]} not updated")
+        expect(updater).to have_received(:log).with(cannot_update_message)
       end
 
       context "and no dependencies were updated" do
@@ -107,11 +110,11 @@ describe Bummr::Updater do
 
       it "logs that it's not updated to the latest" do
         not_latest_message =
-          "#{gem[:name]} not updated from #{gem[:installed]} to latest: #{gem[:newest]}"
+          "Newer #{gem[:name]} installed - updated from #{gem[:installed]} to #{intermediate_version} (latest: #{gem[:newest]})"
 
         updater.update_gem(gem, 0)
 
-        expect(updater).to have_received(:log).with not_latest_message
+        expect(updater).to have_received(:log).with(not_latest_message)
       end
 
       it "commits" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,3 +11,16 @@ require 'pry'
 require 'bummr'
 require 'rainbow/ext/string'
 require 'jet_black/rspec'
+
+# Disable all colorize methods both in lib and spec files
+# This makes it easier to compare plain strings
+Rainbow.enabled = false
+
+=begin
+RSpec.configure do |config|
+  # NOTE: before(:suite) does not allow mocking (allow, or allow_any_instance_of)
+  config.before(:each) do
+
+  end
+end
+=end


### PR DESCRIPTION
- Add spacing between iterations of gem update loop
- Print the "bundle outdated" command that is used
- Disable all colorize methods both in lib and spec files. Easier to diff plain strings
- Modify "gem not updated to latest" message/colors
- Added printout when gem IS updated to latest version