### PR TITLE
fixes < New option

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bummr (1.2.0)
+    bummr (1.2.1b)
       rainbow
       thor
 

--- a/lib/bummr/cli.rb
+++ b/lib/bummr/cli.rb
@@ -8,6 +8,13 @@ module Bummr
     include Bummr::Prompt
     include Bummr::Scm
 
+    desc 'version', '(-v, --version) Display the current version of the gem'
+    map %w[-v --version] => :version
+
+    def version
+      puts "Bummr #{VERSION}"
+    end
+
     # :nocov: internals are tested by spec/check_spec.rb
     desc "check", "Run automated checks to see if bummr can be run"
     def check(fullcheck=true)
@@ -92,7 +99,7 @@ module Bummr
 
     # :nocov: This is stubbed out during actual testing because its boilerplate information for the user
     def display_info
-      puts "Bummr #{VERSION}"
+      puts version
       puts "To run Bummr, you must:"
       puts "- Be in the root path of a clean git branch off of " + "#{BASE_BRANCH}".color(:yellow)
       puts "- Have no commits or local changes"

--- a/lib/bummr/cli.rb
+++ b/lib/bummr/cli.rb
@@ -52,6 +52,7 @@ module Bummr
         else
           Bummr::Updater.new(outdated_gems).update_outdated_gems
 
+          press_any_key("Press any key to start an interactive rebase to adjust the updated gem commits...")
           git.rebase_interactive(BASE_BRANCH)
 
           test unless TEST_COMMAND.empty?

--- a/lib/bummr/cli.rb
+++ b/lib/bummr/cli.rb
@@ -46,7 +46,8 @@ module Bummr
           Bummr::Updater.new(outdated_gems).update_outdated_gems
 
           git.rebase_interactive(BASE_BRANCH)
-          test
+
+          test unless TEST_COMMAND.empty?
         end
       else
         puts "Thank you!".color(:green)
@@ -99,8 +100,10 @@ module Bummr
       puts "- Have your build configured to fail fast (recommended)"
       puts "- Have locked any Gem version that you don't wish to update in your Gemfile"
       puts "- It is recommended that you lock your versions of 'ruby' and 'rails' in your 'Gemfile'"
-      puts "\n"
-      puts "Your test command is: " + "'#{TEST_COMMAND}'".color(:yellow)
+      unless TEST_COMMAND.empty?
+        puts "\n"
+        puts "Your test command is: " + "'#{TEST_COMMAND}'".color(:yellow)
+      end
       puts "\n"
       print_received_options
     end

--- a/lib/bummr/prompt.rb
+++ b/lib/bummr/prompt.rb
@@ -1,3 +1,5 @@
+require 'io/console' # to enable STDIN.getch
+
 module Bummr
   module Prompt
     def yes?(txt, *args)
@@ -7,6 +9,14 @@ module Bummr
         true
       else
         super
+      end
+    end
+
+    def press_any_key(txt)
+      unless headless?
+        puts "\n#{txt}\n"
+        # TODO: "ctrl c" should not be captured
+        STDIN.getch # Waits for a single key press
       end
     end
 

--- a/lib/bummr/prompt.rb
+++ b/lib/bummr/prompt.rb
@@ -1,7 +1,13 @@
 module Bummr
   module Prompt
-    def yes?(*args)
-      headless? || super
+    def yes?(txt, *args)
+      if headless?
+        # don't let this get mocked out along with other "puts"
+        STDOUT.puts txt
+        true
+      else
+        super
+      end
     end
 
     private

--- a/lib/bummr/version.rb
+++ b/lib/bummr/version.rb
@@ -1,3 +1,3 @@
 module Bummr
-  VERSION = "1.2.0"
+  VERSION = "1.2.1b".freeze
 end

--- a/spec/black_box/bummr_update_spec.rb
+++ b/spec/black_box/bummr_update_spec.rb
@@ -6,6 +6,7 @@ describe "bummr update command" do
     puts "\n<< black_box/bummr_update_spec >>\n"
   end
 
+  # REM: the JetBlack session captures all STDOUT and STDERR output originating within the session
   let(:session) { JetBlack::Session.new(options: { clean_bundler_env: true }) }
   let(:bummr_gem_path) { File.expand_path("../../", __dir__) }
 
@@ -43,9 +44,14 @@ describe "bummr update command" do
 
     update_result = session.run(
       "bundle exec bummr update",
-      stdin: "y\ny\ny\n",
+      # yes start bummr
+      # yes bypass errors
+      # yes test build
+      stdin: ['y', 'y', 'y', ''].join("\n"),
       env: { EDITOR: nil, BUMMR_HEADLESS: "true" },
     )
+    # Debugging
+    #puts update_result.stdout
 
     rake_gem_updated = /Update rake from 10\.\d\.\d to 1[1-9]\.\d\.\d/
 

--- a/spec/black_box/bummr_version_spec.rb
+++ b/spec/black_box/bummr_version_spec.rb
@@ -1,0 +1,54 @@
+require "spec_helper"
+require "jet_black"
+
+describe "bummr version command" do
+  before(:all) do
+    puts "\n<< black_box/bummr_version_spec >>\n"
+  end
+
+  # REM: the JetBlack session captures all STDOUT and STDERR output originating within the session
+  let(:session) { JetBlack::Session.new(options: { clean_bundler_env: true }) }
+
+  let(:bummr_gem_path) { File.expand_path("../../", __dir__) }
+
+  let(:version_out) { "Bummr #{Bummr::VERSION}" }
+
+  # Install bummr into this black_box session construct
+  def mock_gemfile_and_install
+    session.create_file "Gemfile", <<~RUBY
+      source "https://rubygems.org"
+      gem "bummr", path: "#{bummr_gem_path}"
+    RUBY
+    session.run("bundle install --retry 3")
+  end
+
+  context "via 'bummr version'" do
+    it "prints the bummr version" do
+      mock_gemfile_and_install
+
+      version_result = session.run(
+        "bundle exec bummr version"
+      )
+      # Debugging
+      #puts version_result.stdout
+      #puts version_result.stderr
+
+      expect(version_result).to have_stdout(version_out)
+    end
+  end
+
+  # -v is also implied to be working since its defined the same way
+  context "via 'bummr --version'" do
+    it "prints the bummr version" do
+      mock_gemfile_and_install
+
+      version_result = session.run(
+        "bundle exec bummr --version"
+      )
+      # Debugging
+      #puts version_result.stdout
+
+      expect(version_result).to have_stdout(version_out)
+    end
+  end
+end

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -39,6 +39,7 @@ describe Bummr::CLI do
         expect(cli).to receive(:yes?).and_return(true)
         expect(cli).to receive(:check)
         expect(cli).to receive(:log)
+        expect(cli).to receive(:press_any_key) # NOOP this function call
         expect(cli).to receive(:system).with("bundle install")
         expect(Bummr::Updater).to receive(:new).with(outdated_gems).and_return updater
         expect(cli).to receive(:test)

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -19,6 +19,15 @@ describe Bummr::CLI do
     ]
   }
 
+  describe "#version" do
+    it "prints the bummr version" do
+      expect(cli).to receive(:puts).with("Bummr #{Bummr::VERSION}")
+
+      cli.version
+    end
+    # See also black_box/bummr_version_spec.rb
+  end
+
   describe "#update" do
     context "when user rejects moving forward" do
       it "does not attempt to move forward" do
@@ -183,4 +192,5 @@ describe Bummr::CLI do
       expect(bisecter).to have_received(:bisect)
     end
   end
+
 end

--- a/spec/lib/prompt_spec.rb
+++ b/spec/lib/prompt_spec.rb
@@ -55,4 +55,38 @@ describe Bummr::Prompt do
 
   end # describe "#yes?"
 
+  describe "#press_any_key" do
+
+    context "when HEADLESS" do
+      it "does nothing" do
+        stub_const("HEADLESS", true)
+
+        allow(STDIN).to receive(:getch)
+
+        expect(
+          object.press_any_key("Press any key to continue...")
+        ).to eq nil
+        # TODO: is there a better way?
+
+        expect(STDIN).not_to have_received(:getch)
+      end
+    end
+
+    context "when not headless" do
+      it "prints message and waits for a keystroke" do
+        stub_const("HEADLESS", false)
+
+        # Fake the user pressing any key
+        allow(STDIN).to receive(:getch).and_return("a")
+
+        expect {
+          object.press_any_key("Press any key to continue...")
+        }.to output("\nPress any key to continue...\n").to_stdout
+
+        expect(STDIN).to have_received(:getch)
+      end
+    end
+
+  end # describe "#press_any_key"
+
 end

--- a/spec/lib/prompt_spec.rb
+++ b/spec/lib/prompt_spec.rb
@@ -42,6 +42,7 @@ describe Bummr::Prompt do
 
     context "when HEADLESS is true" do
       it "returns true and skips asking for user input" do
+        allow(STDOUT).to receive(:puts) # NOOP this particular case
         stub_const("HEADLESS", true)
 
         expect(

--- a/spec/lib/prompt_spec.rb
+++ b/spec/lib/prompt_spec.rb
@@ -5,6 +5,7 @@ describe Bummr::Prompt do
     puts "\n<< Bummr::Prompt >>\n"
   end
 
+  # Mock the parent class, so `super` has some effect (normally super calls Thor.yes?)
   let(:parent_class) do
     Class.new do
       def yes?(message)
@@ -20,6 +21,7 @@ describe Bummr::Prompt do
   end
 
   describe "#yes?" do
+
     context "when HEADLESS is false" do
       it "calls super" do
         stub_const("HEADLESS", false)
@@ -50,5 +52,7 @@ describe Bummr::Prompt do
         ).to eq true
       end
     end
-  end
+
+  end # describe "#yes?"
+
 end


### PR DESCRIPTION
- `BUMMR_TEST=""` now skips the test routine entirely
- added `--version` to print the gem version
  - added spec testing
- Also send to STDOUT whatever `yes?` receives in HEADLESS mode
- Pause before continuing to interactive rebase
  - Stub this out in regular spec testing
  - Added test for this